### PR TITLE
CONSULT-350 - fix android builds

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,36 +1,29 @@
 ANDROID_OUT=../android/src/main/jniLibs
 ANDROID_SDK=$(HOME)/Library/Android/sdk
-NDK_BIN=$(ANDROID_SDK)/ndk/23.1.7779620/toolchains/llvm/prebuilt/darwin-x86_64/bin
+NDK_BIN=$(ANDROID_SDK)/ndk/28.0.12433566/toolchains/llvm/prebuilt/darwin-x86_64/bin
 LIB_NAME=libsum
 
 android-armv7a:
-	CGO_ENABLED=1 \
-	GOOS=android \
-	GOARCH=arm \
-	GOARM=7 \
+	GOOS=android GOARCH=arm GOARM=7 CGO_ENABLED=1 \
 	CC=$(NDK_BIN)/armv7a-linux-androideabi21-clang \
-	go build -buildmode=c-shared -o $(ANDROID_OUT)/armeabi-v7a/${LIB_NAME}.so .
+	go build -ldflags="-checklinkname=0" -buildmode=c-shared -o $(ANDROID_OUT)/armeabi-v7a/${LIB_NAME}.so .
 
 android-arm64:
-	CGO_ENABLED=1 \
-	GOOS=android \
-	GOARCH=arm64 \
+	GOOS=android GOARCH=arm64 CGO_ENABLED=1 \
 	CC=$(NDK_BIN)/aarch64-linux-android21-clang \
-	go build -buildmode=c-shared -o $(ANDROID_OUT)/arm64-v8a/${LIB_NAME}.so .
+	go build -ldflags="-checklinkname=0" -buildmode=c-shared -o $(ANDROID_OUT)/arm64-v8a/${LIB_NAME}.so .
 
 android-x86:
-	CGO_ENABLED=1 \
-	GOOS=android \
-	GOARCH=386 \
+	GOOS=android GOARCH=386 CGO_ENABLED=1 \
 	CC=$(NDK_BIN)/i686-linux-android21-clang \
-	go build -buildmode=c-shared -o $(ANDROID_OUT)/x86/${LIB_NAME}.so .
+	go build -ldflags="-checklinkname=0" -buildmode=c-shared -o $(ANDROID_OUT)/x86/${LIB_NAME}.so .
 
 android-x86_64:
-	CGO_ENABLED=1 \
-	GOOS=android \
-	GOARCH=amd64 \
+	GOOS=android GOARCH=amd64 CGO_ENABLED=1 \
 	CC=$(NDK_BIN)/x86_64-linux-android21-clang \
-	go build -buildmode=c-shared -o $(ANDROID_OUT)/x86_64/${LIB_NAME}.so .
+	go build -ldflags="-checklinkname=0" -buildmode=c-shared -o $(ANDROID_OUT)/x86_64/${LIB_NAME}.so .
+
+android: android-armv7a android-arm64 android-x86 android-x86_64
 
 ios-x86_64-sim:
 	GOARCH=amd64 \
@@ -50,7 +43,6 @@ ios-arm64:
 	LIB_NAME=${LIB_NAME} \
 	./build_ios.sh
 
-android: android-armv7a android-arm64 android-x86 android-x86_64
 
 ios: ios-x86_64-sim ios-arm64-sim ios-arm64
 	lipo \


### PR DESCRIPTION
i am on the latest version of go - a dep of our go library needs the -checklinkname=0 flag

also the NDK is being overridden to an old version on line 3